### PR TITLE
Remove wrapping div

### DIFF
--- a/src/FeatureToggle.jsx
+++ b/src/FeatureToggle.jsx
@@ -1,19 +1,22 @@
-import React from 'react';
+import React, { PropTypes, Component } from 'react';
 
-const FeatureToggle = ({ featureName, showOnlyWhenDisabled, children }, context) => {
-  const toggleState = context.featureToggleList[featureName];
-  const showContent = toggleState === !showOnlyWhenDisabled;
-  return showContent ? <div>{children}</div> : null;
-};
+class FeatureToggle extends Component {
+  render() {
+    const toggleState = this.context.featureToggleList[this.props.featureName];
+    const showContent = toggleState === !this.props.showOnlyWhenDisabled;
+
+    return showContent ? this.props.children : null;
+  }
+}
 
 FeatureToggle.contextTypes = {
-  featureToggleList: React.PropTypes.objectOf(React.PropTypes.bool).isRequired
+  featureToggleList: PropTypes.objectOf(PropTypes.bool).isRequired
 };
 
 FeatureToggle.propTypes = {
-  featureName: React.PropTypes.string.isRequired,
-  children: React.PropTypes.node,
-  showOnlyWhenDisabled: React.PropTypes.bool
+  featureName: PropTypes.string.isRequired,
+  children: PropTypes.node,
+  showOnlyWhenDisabled: PropTypes.bool
 };
 
 export default FeatureToggle;

--- a/test/FeatureToggle.test.jsx
+++ b/test/FeatureToggle.test.jsx
@@ -2,8 +2,8 @@ import { React, Enzyme, expect } from './TestHelpers';
 import { FeatureToggle } from '../src';
 
 describe('<FeatureToggle />', () => {
-  const aChildComponent = (<div>Yay i am a child</div>);
-  const expectedHtmlContent = '<div>Yay i am a child</div>';
+  const aChildComponent = (<div>Yay I am a child</div>);
+  const expectedHtmlContent = '<div>Yay I am a child</div>';
 
   const featureNames = {
     thisOneIsEnabled: 'thisOneIsEnabled',
@@ -73,7 +73,7 @@ describe('<FeatureToggle />', () => {
       expect(featureToggle.html()).to.equal(expectedHtmlContent);
     });
 
-    it('does not render children is toggle with name is enabled and flag is set', () => {
+    it('does not render children if toggle with name is enabled and flag is set', () => {
       const featureToggle = Enzyme.shallow(
         <FeatureToggle featureName={featureNames.thisOneIsEnabled} showOnlyWhenDisabled>
           {aChildComponent}

--- a/test/FeatureToggle.test.jsx
+++ b/test/FeatureToggle.test.jsx
@@ -3,6 +3,7 @@ import { FeatureToggle } from '../src';
 
 describe('<FeatureToggle />', () => {
   const aChildComponent = (<div>Yay i am a child</div>);
+  const expectedHtmlContent = '<div>Yay i am a child</div>';
 
   const featureNames = {
     thisOneIsEnabled: 'thisOneIsEnabled',
@@ -27,6 +28,17 @@ describe('<FeatureToggle />', () => {
     expect(featureToggle.contains(aChildComponent)).to.equal(true);
   });
 
+  it('does not render wrapping div (or any other tag) - just children', () => {
+    const featureToggle = Enzyme.shallow(
+        <FeatureToggle featureName={featureNames.thisOneIsEnabled}>
+          {aChildComponent}
+        </FeatureToggle>,
+        { context }
+    );
+
+    expect(featureToggle.html()).to.equal(expectedHtmlContent);
+  });
+
   it('does not render children is toggle with name is not enabled', () => {
     const featureToggle = Enzyme.shallow(
       <FeatureToggle featureName={featureNames.thisOneIsDisabled}>
@@ -48,6 +60,17 @@ describe('<FeatureToggle />', () => {
       );
 
       expect(featureToggle.contains(aChildComponent)).to.equal(true);
+    });
+
+    it('does not render wrapping div (or any other tag) - just children', () => {
+      const featureToggle = Enzyme.shallow(
+          <FeatureToggle featureName={featureNames.thisOneIsDisabled} showOnlyWhenDisabled>
+            {aChildComponent}
+          </FeatureToggle>,
+          { context }
+      );
+
+      expect(featureToggle.html()).to.equal(expectedHtmlContent);
     });
 
     it('does not render children is toggle with name is enabled and flag is set', () => {

--- a/test/FeatureToggle.test.jsx
+++ b/test/FeatureToggle.test.jsx
@@ -2,7 +2,7 @@ import { React, Enzyme, expect } from './TestHelpers';
 import { FeatureToggle } from '../src';
 
 describe('<FeatureToggle />', () => {
-  const aChildComponent = (<div>Yay I am a child</div>);
+  const aChildComponent = <div>Yay I am a child</div>;
   const expectedHtmlContent = '<div>Yay I am a child</div>';
 
   const featureNames = {


### PR DESCRIPTION
Currently `FeatureToggle` component wraps its children with `div`. This might result in unwanted behaviour, like:
 - altering HTML structure
```
<li>...</li>
<div><li>...</li></div> // <-- toggled li element
<li>...</li>
```
 - breaking stylesheets (one would expect a tag directly from a child not div, thus styles would break).

This PR is meant to return only children without wrapping `div` tag.
